### PR TITLE
Add netlify config, ARIA accessibility, and PWA cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,18 +29,16 @@ Uses Python's built-in HTTP server (no Node required):
 - Merging to `master` triggers an automatic Netlify deploy
 - Remote: git@github.com:lfernandez79/pwdGenerator.git (SSH)
 
-## Known audit items (pending)
-- [ ] Remove `console.log` statements from script.js
-- [ ] Migrate to ES Modules (`type="module"`)
-- [ ] Add copy-to-clipboard via `navigator.clipboard.writeText()`
-- [ ] Remove dead code: `hsimp.min.js` loaded but never used
-- [ ] Add `netlify.toml` for cache/security headers
-- [ ] Fix fragile charString charset management (replace with array/Set)
-- [ ] Add ARIA attributes for accessibility
-- [ ] Complete or remove PWA manifest/service worker
-
 ## Completed improvements
 - [x] Replace `Math.random()` with `crypto.getRandomValues()` for secure generation
 - [x] Fix empty selection guard — `return` early instead of `location.reload()`
 - [x] Add `.claude/` to `.gitignore`
 - [x] Remove unused `package.json` and `package-lock.json`
+- [x] Remove `console.log` statements from script.js
+- [x] Remove dead code: `hsimp.min.js` (references and file)
+- [x] Fix fragile charString charset management (replaced with Set-based approach)
+- [x] Add copy-to-clipboard via `navigator.clipboard.writeText()`
+- [x] Migrate to ES Modules (`type="module"`)
+- [x] Add `netlify.toml` for cache/security headers
+- [x] Add ARIA attributes for accessibility
+- [x] Clean up PWA manifest (removed broken duplicate `site.webmanifest`)

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
         <link rel="icon" type="image/png" sizes="32x32" href="public/assets/image/icons/favicon_io/favicon-32x32.png">
         <link rel="icon" type="image/png" sizes="16x16" href="public/assets/image/icons/favicon_io/favicon-16x16.png">
         <link rel="manifest" href="manifest.json">
-        <link rel="manifest" href="public/assets/image/icons/favicon_io/site.webmanifest">
         <script src="https://kit.fontawesome.com/291451fd76.js" crossorigin="anonymous"></script>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css"
             integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
@@ -28,15 +27,17 @@
             <section class="text-center">
                 <div class="">
                     <p class="text-center" readonly id="password" placeholder="Password"
-                        aria-label="Generated Password"></p>
-                    <button type="button" id="copy" class="btn btn-sm btn-outline-light" style="display:none;">
+                        aria-label="Generated Password" aria-live="polite" role="status"></p>
+                    <button type="button" id="copy" class="btn btn-sm btn-outline-light" style="display:none;"
+                        aria-label="Copy password to clipboard">
                         <i class="fas fa-copy"></i> Copy
                     </button>
-                    <h2 id="counter"></h2>
+                    <h2 id="counter" aria-live="polite"></h2>
                     <fieldset>
                         <p>Num of characters: <span id="sliderCounter"></span></p>
                         <label for="customRange1">Use slider to pick number of characters?</label>
-                        <input type="range" class="custom-range" id="customRange1" min="8" max="30" value="8">
+                        <input type="range" class="custom-range" id="customRange1" min="8" max="30" value="8"
+                            aria-label="Password character length" aria-valuemin="8" aria-valuemax="30" aria-valuenow="8">
                     </fieldset>
                 </div>
                 <div class="row justify-content-center">

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,28 @@
+[build]
+  publish = "."
+
+# Cache static assets (images, icons) for 1 year
+[[headers]]
+  for = "/public/assets/image/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# Cache CSS and JS for 1 hour (allows quick updates)
+[[headers]]
+  for = "/public/assets/style/*"
+  [headers.values]
+    Cache-Control = "public, max-age=3600"
+
+[[headers]]
+  for = "/public/assets/JS/*"
+  [headers.values]
+    Cache-Control = "public, max-age=3600"
+
+# Security headers for all pages
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"

--- a/public/assets/JS/script.js
+++ b/public/assets/JS/script.js
@@ -20,6 +20,7 @@ const charSets = [
 output.textContent = slider.value;
 slider.oninput = () => {
   output.textContent = slider.value;
+  slider.setAttribute("aria-valuenow", slider.value);
 };
 
 const selectedSets = new Set();

--- a/public/assets/image/icons/favicon_io/site.webmanifest
+++ b/public/assets/image/icons/favicon_io/site.webmanifest
@@ -1,1 +1,0 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}


### PR DESCRIPTION
## Summary
Final 3 items from the modernization audit, one per commit:

**1. Add `netlify.toml` with cache and security headers** (`3144c8a`)
- Cache images/icons for 1 year, CSS/JS for 1 hour
- Security headers: `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`

**2. Add ARIA attributes and clean up PWA manifest** (`75ee8fc`)
- `aria-live="polite"` + `role="status"` on password display so screen readers announce new passwords
- `aria-live="polite"` on countdown counter
- `aria-label` on copy button and range slider
- `aria-valuemin/max/now` on slider, updated dynamically via JS
- Remove duplicate broken `site.webmanifest` link and file; keep `manifest.json` as single correct manifest

**3. Update CLAUDE.md — all audit items complete** (`a421455`)

## Test plan
- [x] All ARIA attributes present in DOM
- [x] Slider `aria-valuenow` updates dynamically when moved
- [x] Single manifest link (no duplicate `site.webmanifest`)
- [x] Password generation, copy-to-clipboard, and countdown all still functional
- [x] `netlify.toml` syntax valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)