### PR TITLE
Scale up UI for desktop/laptop screens

### DIFF
--- a/public/assets/style/style.css
+++ b/public/assets/style/style.css
@@ -24,7 +24,7 @@ main {
   border-radius: 16px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5), 0 6px 20px rgba(0, 0, 0, 0.4);
   padding: 2.5rem;
-  max-width: 520px;
+  max-width: 600px;
   width: 100%;
   text-align: center;
 }
@@ -242,7 +242,60 @@ footer {
   font-size: 1.2rem;
 }
 
-/* Responsive */
+/* Desktop scale-up */
+@media (min-width: 768px) {
+  main {
+    padding: 3rem 3.5rem;
+  }
+
+  h1 {
+    font-size: 2.8rem;
+  }
+
+  #password {
+    font-size: 2.2rem;
+  }
+
+  #counter {
+    font-size: 2rem;
+  }
+
+  .slider-group label {
+    font-size: 1.3rem;
+  }
+
+  .slider-group span {
+    font-size: 1.5rem;
+  }
+
+  input[type="range"] {
+    width: 60%;
+  }
+
+  .toggle {
+    font-size: 1.3rem;
+  }
+
+  .toggles {
+    max-width: 380px;
+  }
+
+  #generate {
+    font-size: 1.2rem;
+    padding: 0.75rem 2rem;
+  }
+
+  #reset {
+    font-size: 1.1rem;
+    padding: 0.75rem 2rem;
+  }
+
+  #copy {
+    font-size: 1.1rem;
+  }
+}
+
+/* Mobile */
 @media (max-width: 480px) {
   main {
     padding: 1.5rem;


### PR DESCRIPTION
## Summary
- Increase card max-width from 520px to 600px
- Add desktop media query (min-width: 768px) that proportionally scales up title, password, countdown, slider, toggles, buttons, and padding
- Mobile layout unchanged

## Test plan
- [x] Desktop — card fills more of the viewport, all elements proportionally larger
- [x] Mobile — layout unchanged, buttons stacked, compact spacing
- [x] Full generate → reset → generate cycle works on both viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)